### PR TITLE
Fix empty output calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Screeps Profiler [![Build Status](https://travis-ci.org/gdborton/screeps-profiler.svg?branch=master)](https://travis-ci.org/gdborton/screeps-profiler) [![Coverage Status](https://coveralls.io/repos/github/gdborton/screeps-profiler/badge.svg)](https://coveralls.io/github/gdborton/screeps-profiler)
+# Screeps Profiler [![Build Status](https://travis-ci.org/screepers/screeps-profiler.svg?branch=master)](https://travis-ci.org/screepers/screeps-profiler) [![Coverage Status](https://coveralls.io/repos/github/screepers/screeps-profiler/badge.svg)](https://coveralls.io/github/screepers/screeps-profiler)
 
 The Screeps Profiler is a library that helps to understand where your CPU is being spent in the game of [Screeps](https://screeps.com).
 

--- a/__tests__/screeps-profiler.js
+++ b/__tests__/screeps-profiler.js
@@ -98,6 +98,11 @@ describe('screeps-profiler', () => {
     });
 
     describe('output', () => {
+      it('does not explode if there are no profiled functions', () => {
+        Game.profiler.profile(10);
+        expect(profiler.output).not.toThrow();
+      });
+
       it('correctly limits the length of the output', () => {
         Game.profiler.profile(10);
         let functionsWrappedAndRan = 0;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -208,7 +208,7 @@ const Profiler = {
     let currentLength = header.length + 1 + footer.length;
     const allLines = Profiler.lines();
     let done = false;
-    while (!done) {
+    while (!done && allLines.length) {
       const line = allLines.shift();
       // each line added adds the line length plus a new line character.
       if (currentLength + line.length + 1 < outputLengthLimit) {


### PR DESCRIPTION
This fixes - https://github.com/screepers/screeps-profiler/issues/25

Basically the output function was assuming there was always more content than
could be displayed using the provided character limit.