### PR TITLE
Fix tick calculation: Output will always be 2 less

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -195,8 +195,8 @@ const Profiler = {
     }
 
     const endTick = Math.min(Memory.profiler.disableTick || Game.time, Game.time);
-    const startTick = Memory.profiler.enabledTick + 1;
-    const elapsedTicks = endTick - startTick;
+    const startTick = Memory.profiler.enabledTick;
+    const elapsedTicks = endTick - startTick + 1;
     const header = 'calls\t\ttime\t\tavg\t\tfunction';
     const footer = [
       `Avg: ${(Memory.profiler.totalTime / elapsedTicks).toFixed(2)}`,


### PR DESCRIPTION
Simply put, a previous refactor incorrectly altered the way the elapsed ticks was calculated.

Previously, if given the following:
```
//Game.time === 120;
Game.profiler.profile(5)
Memory.profiler.enabledTick = 120; // correct
Memory.profiler.disableTick = 124; // correct
```

Then after 5 ticks, the calculation would be:
```
const endTick = Math.min(Memory.profiler.disableTick || Game.time, Game.time); // 124
const startTick = Memory.profiler.enabledTick + 1; // 121
const elapsedTicks = endTick - startTick; // 3
```

Given the above, elapsedTicks would be 3, which is 2 less than what the original input of 5 was.