### PR TITLE
Update callgrind filename format to match MIME type glob patterns

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -243,7 +243,7 @@ const Profiler = {
   downloadCallgrind() {
     const id = `id${Math.random()}`;
     const shardId = Game.shard.name + (Game.shard.ptr ? '-ptr' : '');
-    const filename = `callgrind.${shardId}.${Game.time}`;
+    const filename = `callgrind.out.${shardId}.${Game.time}`;
     const data = Profiler.callgrind();
     if (!data) {
       console.log('No profile data to download');


### PR DESCRIPTION
This project's README specifically recommends KCachegrind for viewing callgrind output, but the files created by the profiler are identified as `text/plain` files, rather than `application/x-kcachegrind` files.

As such, they cannot be easily associated with KCachegrind or other related apps, and they do not show up by default in KCachegrind's File Open dialog.

The glob pattern for `application/x-kcachegrind` is `callgrind.out*`. This change updates the filename format to match that pattern.